### PR TITLE
Fixing bug about frame drop log

### DIFF
--- a/python/viewer/image_viewer.py
+++ b/python/viewer/image_viewer.py
@@ -103,10 +103,10 @@ def main():
                     timestamp = image_pc_pair.image.timestamp
                     frame_id = image_pc_pair.image.frame_id
 
-                    if frame_id - last_frame_id > 1 and frame_id > 0:
-                        print("DROP FRAME DETECTED: %d" % frame_id)
+                if frame_id - last_frame_id > 1 and frame_id > 0:
+                    print("DROP FRAME DETECTED: %d" % frame_id)
 
-                    last_frame_id = frame_id
+                last_frame_id = frame_id
 
                 if args.show_timestamp:
                     im_rgb = overlay_timestamp(timestamp, frame_id, im_rgb)


### PR DESCRIPTION
We want to have the frame drop detection log be printed for Imaging-only, Tracking-only and Imaging+Tracking. Currently, it is only for Imaging-only, I don't think it is the expected behavior.

@osamasal  I put you as a reviewer, because we just discussed it