### PR TITLE
Add more testing to the example code

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -23,10 +23,15 @@ debian:
 
 protocol: debian
 	${PROTOC} -I=${ZENDAR_PROTO_PATH} --cpp_out=${ZENDAR_PROTO_PATH} ${ZENDAR_PROTO_PATH}/*.proto
-	${CXX} -fPIC ${ZENDAR_PROTO_PATH}/*.pb.cc -shared -o ${ZENDAR_INSTALL_PATH}/libzenproto.so
+	${CXX} -fPIC ${ZENDAR_PROTO_PATH}/*.pb.cc -shared -lprotobuf -o ${ZENDAR_INSTALL_PATH}/libzenproto.so
 	cp ${ZENDAR_PROTO_PATH}/*.pb.h ${ZENDAR_INSTALL_PATH}
 
-example: example.cc
+example: example-simple example-receiver
+
+example-simple: example-simple.cc
+	${CXX} $< -I${ZENDAR_INSTALL_PATH} ${LIBPATH} ${LINKFLAGS} -o $@
+
+example-receiver: example-receiver.cc
 	${CXX} $< -I${ZENDAR_INSTALL_PATH} ${LIBPATH} ${LINKFLAGS} -o $@
 
 clean:

--- a/cpp/example-receiver.cc
+++ b/cpp/example-receiver.cc
@@ -1,0 +1,56 @@
+#include "zendar-api.h"
+#include "data.pb.h"
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    printf("Usage: example-receiver URI");
+  }
+  zendar::ZendarReceiver rcv(argv[1]);
+  rcv.SubscribeImages(100);
+  rcv.SubscribeTracker(100);
+  rcv.SubscribeTracklog(100);
+  rcv.SubscribeLogs(100);
+
+  printf("Successful Initialization\n");
+  zen_proto::data::Image image;
+  zen::tracker::message::TrackerState tracker_state;
+  zen_proto::data::Position position;
+  zen_proto::data::LogRecord log;
+
+  zendar::ZendarError error;
+  for (int i=0; i<10; ++i) {
+    error = rcv.NextImage(image);
+    if (error) {
+      printf("Failed to receive image\n");
+    } else {
+      printf("Received image, timestamp: %f \n", image.timestamp());
+    }
+    error = rcv.NextTracker(tracker_state);
+    if (error) {
+      printf("Failed to receive tracker_state\n");
+    } else {
+      printf("Received image, timestamp: %f \n",
+             tracker_state.timestamp().common());
+    }
+    error = rcv.NextTracklog(position);
+    if (error) {
+      printf("Failed to receive position\n");
+    } else {
+      printf("Received position:\n %f\n %f\n %f \n",
+             position.position().x(),
+             position.position().y(),
+             position.position().z());
+    }
+    error = rcv.NextLogMessage(log);
+    if (error) {
+      printf("Failed to receive log\n");
+    } else {
+      printf("Received log: %s\n", log.message().c_str());
+    }
+  }
+  rcv.UnsubscribeImages();
+  rcv.UnsubscribeTracker();
+  rcv.UnsubscribeTracklog();
+  rcv.UnsubscribeLogs();
+  return 1;
+}

--- a/cpp/example-receiver.cc
+++ b/cpp/example-receiver.cc
@@ -29,7 +29,7 @@ int main(int argc, char* argv[]) {
     if (error) {
       printf("Failed to receive tracker_state\n");
     } else {
-      printf("Received image, timestamp: %f \n",
+      printf("Received tracker_state, timestamp: %f \n",
              tracker_state.timestamp().common());
     }
     error = rcv.NextTracklog(position);

--- a/cpp/example-receiver.cc
+++ b/cpp/example-receiver.cc
@@ -6,10 +6,20 @@ int main(int argc, char* argv[]) {
     printf("Usage: example-receiver URI");
   }
   zendar::ZendarReceiver rcv(argv[1]);
-  rcv.SubscribeImages(100);
-  rcv.SubscribeTracker(100);
-  rcv.SubscribeTracklog(100);
-  rcv.SubscribeLogs(100);
+  zendar::ZendarError error;
+
+  error = rcv.SubscribeImages(100);
+  if (error)
+    printf("Failed to subscribe to images");
+  error = rcv.SubscribeTracker(100);
+  if (error)
+    printf("Failed to subscribe to tracker");
+  error = rcv.SubscribeTracklog(100);
+  if (error)
+    printf("Failed to subscribe to tracklog");
+  error = rcv.SubscribeLogs(100);
+  if (error)
+    printf("Failed to subscribe to logs");
 
   printf("Successful Initialization\n");
   zen_proto::data::Image image;
@@ -17,8 +27,7 @@ int main(int argc, char* argv[]) {
   zen_proto::data::Position position;
   zen_proto::data::LogRecord log;
 
-  zendar::ZendarError error;
-  for (int i=0; i<10; ++i) {
+  for (int i = 0; i < 10; ++i) {
     error = rcv.NextImage(image);
     if (error) {
       printf("Failed to receive image\n");
@@ -48,9 +57,18 @@ int main(int argc, char* argv[]) {
       printf("Received log: %s\n", log.message().c_str());
     }
   }
-  rcv.UnsubscribeImages();
-  rcv.UnsubscribeTracker();
-  rcv.UnsubscribeTracklog();
-  rcv.UnsubscribeLogs();
+  error = rcv.UnsubscribeImages();
+  if (error)
+    printf("Failed to unsubscribe from images");
+  error = rcv.UnsubscribeTracker();
+  if (error)
+    printf("Failed to unsubscribe from tracker");
+  error = rcv.UnsubscribeTracklog();
+  if (error)
+    printf("Failed to subscribe from tracklog");
+  error = rcv.UnsubscribeLogs();
+  if (error)
+    printf("Failed to subscribe from logs");
+
   return 1;
 }

--- a/cpp/example-simple.cc
+++ b/cpp/example-simple.cc
@@ -1,6 +1,3 @@
-#include <chrono>
-#include <thread>
-
 #include "zendar-api.h"
 #include "data.pb.h"
 


### PR DESCRIPTION
Separates `example.cc` into `example-simple.cc` which is the same, and `example-receiver.cc` which takes in a URI as a parameter and receives from all data streams.