### PR TITLE
Bug fix

### DIFF
--- a/python/viewer/image_viewer.py
+++ b/python/viewer/image_viewer.py
@@ -123,14 +123,13 @@ def main():
                 elif render_data.image is not None:
                     timestamp = render_data.image.timestamp
                     frame_id = render_data.image.frame_id
-
-                if frame_id - last_frame_id > 1 and frame_id > 0:
-                    print("DROP FRAME DETECTED: %d" % frame_id)
-
                 else:
                     # Lidar-only doesn't use the frame_id
                     timestamp = render_data.lidar.timestamp
                     frame_id = 0
+
+                if frame_id - last_frame_id > 1 and frame_id > 0:
+                    print("DROP FRAME DETECTED: %d" % frame_id)
                 last_frame_id = frame_id
 
                 if args.show_timestamp:


### PR DESCRIPTION
When running `image_viewer`:
`python3 ${ZEN_SDK}/python/viewer/image_viewer.py -i /mnt/zen-ffa/shannon/2021-02-08_180946/  -o . --radar-name ZRAA0030  --radar-name ZRAA0031 `

we have this error:

Traceback (most recent call last):
  File "/home/plblossier/Documents/ZendarSDK/python/viewer/image_viewer.py", line 428, in <module>
    main()
  File "/home/plblossier/Documents/ZendarSDK/python/viewer/image_viewer.py", line 132, in main
    timestamp = render_data.lidar.timestamp
AttributeError: 'NoneType' object has no attribute 'timestamp'


This is because the person who added the Lidar support did not put the `else` statement in the good place https://github.com/ZendarInc/ZendarSDK/blob/590d63a3c32033b768ad5f65bac6c347cfe17427/python/viewer/image_viewer.py#L127-L134 probably when solving the conflict.