### PR TITLE
Parallelize radar visualization in image_viewer

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,3 +2,4 @@ numpy
 matplotlib
 opencv-python
 protobuf
+pyqt5

--- a/python/viewer/image_viewer.py
+++ b/python/viewer/image_viewer.py
@@ -1,13 +1,15 @@
 from os.path import join, exists
-import sys
 from contextlib import ExitStack
 import argparse
 import numpy as np
 from collections import namedtuple
+
+import cv2
+import matplotlib
 from matplotlib import pyplot as plt
 from matplotlib.cm import ScalarMappable
 from matplotlib.colors import Normalize
-import cv2
+
 from multiprocessing import Process
 
 import data_pb2
@@ -35,6 +37,8 @@ RenderData = namedtuple('RenderData', ['image',
                                        'pc',
                                        'lidar'])
 
+# This script was tested with Qt5Agg to provide all the functionnalities
+matplotlib.use('Qt5Agg')
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
When using `image_viewer`, I find a bit annoying that we see only one radar at a time, and the fact that they are successively generated makes the process of obtaining merged video quite long. This is a proposal to make every radar processed in parallel (but not in sync), without changing too much the current logic.

I tested it, and the gain of time is consequent. Let me know what you think of it