### PR TITLE
Fixing matplotlib backend

### DIFF
--- a/python/viewer/image_viewer.py
+++ b/python/viewer/image_viewer.py
@@ -38,7 +38,12 @@ RenderData = namedtuple('RenderData', ['image',
                                        'lidar'])
 
 # This script was tested with Qt5Agg to provide all the functionnalities
-matplotlib.use('Qt5Agg')
+# or headless
+import os
+if 'DISPLAY' not in os.environ or matplotlib.get_backend() == 'agg':
+    matplotlib.use('agg')
+else:
+    matplotlib.use('Qt5Agg')
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
When used in a headless environment (like when sshing), image_viewer was crashing because forced to use Qt5Agg and its GUI. If the matplotlib environment is headless ('agg' backend) or if there is no display available, stay headless. If not, Qt5Agg is still the backend that we want to default to.

@anown0 let me know if it solves the issue on your end.