### PR TITLE
Cartesian type fix

### DIFF
--- a/python/viewer/radar_image.py
+++ b/python/viewer/radar_image.py
@@ -57,6 +57,8 @@ class RadarImage(RadarData):
 
         image_pb.timestamp = timestamp
         image_pb.frame_id = frame_id
+        # Setting the type to REAL_32U
+        image_pb.cartesian.data.type = 5
         array_to_vec3d_pb(image_pb.position,
                           self.extrinsic.position)
 


### PR DESCRIPTION
This fixes this error I was getting:

```
lidar display is turned off
DROP FRAME DETECTED: 1253(ZRAA0030)
[swscaler @ 0x558fb69dd880] Warning: data is not aligned! This can lead to a speed loss
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/mwagner/ZendarSDK/python/viewer/image_viewer.py", line 221, in visualize_single_radar
    proto_writer.write(proto_out)
  File "/home/mwagner/ZendarSDK/python/viewer/radar_data_streamer.py", line 79, in write
    serial = record.SerializeToString()
google.protobuf.message.EncodeError: Message zen_proto.data.Image is missing required fields: cartesian.data.type
```

@ghsyu tracked this down to the `Image.cartesian.data.type` not being set.  This PR now sets it to 5 (i.e. REAL_32U).  I _think_ this is correct, but please check carefully as I'm not familiar with this part of the codebase.
