### PR TITLE
Updating python scripts for new protobufs

### DIFF
--- a/python/viewer/radar_image.py
+++ b/python/viewer/radar_image.py
@@ -26,12 +26,12 @@ class RadarImage(RadarData):
 
     @classmethod
     def from_proto(cls, image_pb):
-        timestamp = image_pb.timestamp
-        frame_id = image_pb.frame_id
+        timestamp = image_pb.meta.timestamp
+        frame_id = image_pb.meta.frame_id
 
         extrinsic = Extrinsic(
-            position=vec3d_to_array(image_pb.position),
-            attitude=quat_to_array(image_pb.attitude))
+            position=vec3d_to_array(image_pb.meta.position),
+            attitude=quat_to_array(image_pb.meta.attitude))
 
         image_model = ImageModel(
             origin=vec3d_to_array(image_pb.cartesian.model.origin),
@@ -55,14 +55,14 @@ class RadarImage(RadarData):
     def to_proto(self, timestamp, frame_id):
         image_pb = Image()
 
-        image_pb.timestamp = timestamp
-        image_pb.frame_id = frame_id
+        image_pb.meta.timestamp = timestamp
+        image_pb.meta.frame_id = frame_id
         # Setting the type to REAL_32U
         image_pb.cartesian.data.type = 5
-        array_to_vec3d_pb(image_pb.position,
+        array_to_vec3d_pb(image_pb.meta.position,
                           self.extrinsic.position)
 
-        array_to_quat_pb(image_pb.attitude,
+        array_to_quat_pb(image_pb.meta.attitude,
                          self.extrinsic.attitude)
 
         array_to_vec3d_pb(image_pb.cartesian.model.origin,

--- a/python/viewer/radar_point_cloud.py
+++ b/python/viewer/radar_point_cloud.py
@@ -42,8 +42,8 @@ class RadarPointCloud(RadarData):
 
     @classmethod
     def from_proto(cls, tracker_state_pb):
-        time_record = tracker_state_pb.timestamp
-        frame_id = tracker_state_pb.frame_id
+        tstamp = tracker_state_pb.meta.timestamp
+        frame_id = tracker_state_pb.meta.frame_id
 
         point_cloud = []
         for pt in tracker_state_pb.detection:
@@ -51,7 +51,7 @@ class RadarPointCloud(RadarData):
             if radar_point is not None:
                 point_cloud.append(radar_point)
 
-        radar_point_cloud = cls(time_record.common, frame_id,
+        radar_point_cloud = cls(tstamp, frame_id,
                                 point_cloud)
 
         return radar_point_cloud


### PR DESCRIPTION
With the merge of `feature-platform`, the protobuf definitions for tracking and imaging output slightly changed: metadata have been moved to a `MetaData` message. This PR addresses this change. This has to wait #27 to be merged.