### PR TITLE
Update `start_stop` example with temperature monitoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(zendar-sdk)
 
+set(LOCAL_API  FALSE CACHE BOOL "Path to ZenApi package installation")
+set(SYSTEM_API FALSE CACHE BOOL "Path to ZenApi package installation")
+
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -20,20 +23,33 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
 
 ## common dependencies #########################################################
 
-find_package(GFlags REQUIRED)
-list(APPEND COMMON_INC ${GFLAGS_INCLUDE_DIRS})
-list(APPEND COMMON_DEP ${GFLAGS_LIBRARIES})
-
-find_package(Glog REQUIRED)
-list(APPEND COMMON_INC ${GLOG_INCLUDE_DIRS})
-list(APPEND COMMON_DEP ${GLOG_LIBRARIES})
-
-find_package(Protobuf REQUIRED)
-list(APPEND COMMON_INC ${PROTOBUF_INCLUDE_DIRS})
-list(APPEND COMMON_DEP ${PROTOBUF_LIBRARIES})
-
 list(APPEND COMMON_DEP pthread)
+
+if (LOCAL_API)
+  list(APPEND CMAKE_PREFIX_PATH "$ENV{ZEN_CODE}/build/install/share/zendar/cmake")
+  find_package(ZenApi REQUIRED)
+  list(APPEND COMMON_DEP zen::zendar_api)
+elseif(SYSTEM_API)
+  list(APPEND CMAKE_PREFIX_PATH "/usr/share/zendar/cmake")
+  find_package(ZenApi REQUIRED)
+  list(APPEND COMMON_DEP zen::zendar_api)
+else()
+  find_package(GFlags REQUIRED)
+  list(APPEND COMMON_INC ${GFLAGS_INCLUDE_DIRS})
+  list(APPEND COMMON_DEP ${GFLAGS_LIBRARIES})
+
+  find_package(Glog REQUIRED)
+  list(APPEND COMMON_INC ${GLOG_INCLUDE_DIRS})
+  list(APPEND COMMON_DEP ${GLOG_LIBRARIES})
+
+  find_package(Protobuf REQUIRED)
+  list(APPEND COMMON_INC ${PROTOBUF_INCLUDE_DIRS})
+  list(APPEND COMMON_DEP ${PROTOBUF_LIBRARIES})
+
+  list(APPEND COMMON_DEP zendar_api zendar_common shared_protobuf)
+endif()
+
 
 ## subprojects #################################################################
 
-add_subdirectory(examples)
+add_subdirectory("examples")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
   list(APPEND COMMON_INC ${PROTOBUF_INCLUDE_DIRS})
   list(APPEND COMMON_DEP ${PROTOBUF_LIBRARIES})
 
-  list(APPEND COMMON_DEP zendar_api zendar_common shared_protobuf)
+  list(APPEND COMMON_DEP zendar_api2 zendar_common shared_protobuf)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
 
 ## common dependencies #########################################################
 
-list(APPEND COMMON_DEP pthread)
-
 if (LOCAL_API)
   list(APPEND CMAKE_PREFIX_PATH "$ENV{ZEN_CODE}/build/install/share/zendar/cmake")
   find_package(ZenApi REQUIRED)
@@ -34,6 +32,8 @@ elseif(SYSTEM_API)
   find_package(ZenApi REQUIRED)
   list(APPEND COMMON_DEP zen::zendar_api)
 else()
+  list(APPEND COMMON_DEP zendar_api2 zendar_common shared_protobuf)
+
   find_package(GFlags REQUIRED)
   list(APPEND COMMON_INC ${GFLAGS_INCLUDE_DIRS})
   list(APPEND COMMON_DEP ${GFLAGS_LIBRARIES})
@@ -45,8 +45,6 @@ else()
   find_package(Protobuf REQUIRED)
   list(APPEND COMMON_INC ${PROTOBUF_INCLUDE_DIRS})
   list(APPEND COMMON_DEP ${PROTOBUF_LIBRARIES})
-
-  list(APPEND COMMON_DEP zendar_api2 zendar_common shared_protobuf)
 endif()
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,9 @@
 ## subprojects #################################################################
 
-add_subdirectory(list_modes)
-add_subdirectory(receive_all)
-add_subdirectory(receive_data)
-add_subdirectory(receive_telem)
-add_subdirectory(start_imaging)
-add_subdirectory(stop_imaging)
-add_subdirectory(start_stop)
+add_subdirectory("list_modes")
+add_subdirectory("receive_all")
+add_subdirectory("receive_data")
+add_subdirectory("receive_telem")
+add_subdirectory("start_imaging")
+add_subdirectory("stop_imaging")
+add_subdirectory("start_stop")

--- a/examples/list_modes/CMakeLists.txt
+++ b/examples/list_modes/CMakeLists.txt
@@ -1,13 +1,8 @@
 ## locals ######################################################################
-
-set(_exe list_modes)
-set(_src ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
-set(_inc ${CMAKE_CURRENT_SOURCE_DIR})
-set(_dep zendar_api2 zendar_common shared_protobuf)
+set(exe list_modes)
 
 
 ## targets #####################################################################
-
-add_executable(${_exe} ${_src})
-target_include_directories(${_exe} PUBLIC ${_inc} ${COMMON_INC})
-target_link_libraries(${_exe} PUBLIC ${_dep} ${COMMON_DEP})
+add_executable(${exe} "main.cc")
+target_include_directories(${exe} PUBLIC ${COMMON_INC})
+target_link_libraries(${exe} PUBLIC ${COMMON_DEP})

--- a/examples/receive_all/CMakeLists.txt
+++ b/examples/receive_all/CMakeLists.txt
@@ -1,13 +1,8 @@
 ## locals ######################################################################
-
-set(_exe receive_all)
-set(_src ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
-set(_inc ${CMAKE_CURRENT_SOURCE_DIR})
-set(_dep zendar_api2 zendar_common shared_protobuf)
+set(exe receive_all)
 
 
 ## targets #####################################################################
-
-add_executable(${_exe} ${_src})
-target_include_directories(${_exe} PUBLIC ${_inc} ${COMMON_INC})
-target_link_libraries(${_exe} PUBLIC ${_dep} ${COMMON_DEP})
+add_executable(${exe} "main.cc")
+target_include_directories(${exe} PUBLIC ${COMMON_INC})
+target_link_libraries(${exe} PUBLIC ${COMMON_DEP})

--- a/examples/receive_all/main.cc
+++ b/examples/receive_all/main.cc
@@ -48,8 +48,8 @@ void
 SpinHK()
 {
   while (auto next_hk = ZenApi::NextHousekeepingReport()) {
-    (void)next_hk;
     LOG(INFO) << "SUCCESS Got a Housekeeping Report!";
+    VLOG(1) << next_hk->DebugString();
   }
 }
 

--- a/examples/receive_data/CMakeLists.txt
+++ b/examples/receive_data/CMakeLists.txt
@@ -1,13 +1,8 @@
 ## locals ######################################################################
-
-set(_exe receive_data)
-set(_src ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
-set(_inc ${CMAKE_CURRENT_SOURCE_DIR})
-set(_dep zendar_api2 zendar_common shared_protobuf)
+set(exe receive_data)
 
 
 ## targets #####################################################################
-
-add_executable(${_exe} ${_src})
-target_include_directories(${_exe} PUBLIC ${_inc} ${COMMON_INC})
-target_link_libraries(${_exe} PUBLIC ${_dep} ${COMMON_DEP})
+add_executable(${exe} "main.cc")
+target_include_directories(${exe} PUBLIC ${COMMON_INC})
+target_link_libraries(${exe} PUBLIC ${COMMON_DEP})

--- a/examples/receive_telem/CMakeLists.txt
+++ b/examples/receive_telem/CMakeLists.txt
@@ -1,13 +1,8 @@
 ## locals ######################################################################
-
-set(_exe receive_telem)
-set(_src ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
-set(_inc ${CMAKE_CURRENT_SOURCE_DIR})
-set(_dep zendar_api2 zendar_common shared_protobuf)
+set(exe receive_telem)
 
 
 ## targets #####################################################################
-
-add_executable(${_exe} ${_src})
-target_include_directories(${_exe} PUBLIC ${_inc} ${COMMON_INC})
-target_link_libraries(${_exe} PUBLIC ${_dep} ${COMMON_DEP})
+add_executable(${exe} "main.cc")
+target_include_directories(${exe} PUBLIC ${COMMON_INC})
+target_link_libraries(${exe} PUBLIC ${COMMON_DEP})

--- a/examples/receive_telem/main.cc
+++ b/examples/receive_telem/main.cc
@@ -21,8 +21,8 @@ void
 SpinHK()
 {
   while (auto next_hk = ZenApi::NextHousekeepingReport()) {
-    (void)next_hk;
     LOG(INFO) << "SUCCESS Got a Housekeeping Report!";
+    VLOG(1) << next_hk->DebugString();
   }
 }
 

--- a/examples/start_imaging/CMakeLists.txt
+++ b/examples/start_imaging/CMakeLists.txt
@@ -1,13 +1,8 @@
 ## locals ######################################################################
-
-set(_exe start_imaging)
-set(_src ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
-set(_inc ${CMAKE_CURRENT_SOURCE_DIR})
-set(_dep zendar_api2 zendar_common shared_protobuf)
+set(exe start_imaging)
 
 
 ## targets #####################################################################
-
-add_executable(${_exe} ${_src})
-target_include_directories(${_exe} PUBLIC ${_inc} ${COMMON_INC})
-target_link_libraries(${_exe} PUBLIC ${_dep} ${COMMON_DEP})
+add_executable(${exe} "main.cc")
+target_include_directories(${exe} PUBLIC ${COMMON_INC})
+target_link_libraries(${exe} PUBLIC ${COMMON_DEP})

--- a/examples/start_stop/CMakeLists.txt
+++ b/examples/start_stop/CMakeLists.txt
@@ -1,13 +1,8 @@
 ## locals ######################################################################
-
-set(_exe start_stop)
-set(_src ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
-set(_inc ${CMAKE_CURRENT_SOURCE_DIR})
-set(_dep zendar_api2 zendar_common shared_protobuf)
+set(exe start_stop)
 
 
 ## targets #####################################################################
-
-add_executable(${_exe} ${_src})
-target_include_directories(${_exe} PUBLIC ${_inc} ${COMMON_INC})
-target_link_libraries(${_exe} PUBLIC ${_dep} ${COMMON_DEP})
+add_executable(${exe} "main.cc")
+target_include_directories(${exe} PUBLIC ${COMMON_INC})
+target_link_libraries(${exe} PUBLIC ${COMMON_DEP})

--- a/examples/stop_imaging/CMakeLists.txt
+++ b/examples/stop_imaging/CMakeLists.txt
@@ -1,13 +1,8 @@
 ## locals ######################################################################
-
-set(_exe stop_imaging)
-set(_src ${CMAKE_CURRENT_SOURCE_DIR}/main.cc)
-set(_inc ${CMAKE_CURRENT_SOURCE_DIR})
-set(_dep zendar_api2 zendar_common shared_protobuf)
+set(exe stop_imaging)
 
 
 ## targets #####################################################################
-
-add_executable(${_exe} ${_src})
-target_include_directories(${_exe} PUBLIC ${_inc} ${COMMON_INC})
-target_link_libraries(${_exe} PUBLIC ${_dep} ${COMMON_DEP})
+add_executable(${exe} "main.cc")
+target_include_directories(${exe} PUBLIC ${COMMON_INC})
+target_link_libraries(${exe} PUBLIC ${COMMON_DEP})


### PR DESCRIPTION
Add `--kill_temp` flag (deg-C) that sets the limit for CPU/GPU temperature.

When the temperature reported from the device exceeds this value then the `ZenApi::Stop()` command is called to stop the ZPU.

Also includes some minor clean up to the CMake files.

---

Example

```
> bin/start_stop --device_addr zzab0002.local --imaging_mode evk_modes/ZenCropFieldOp --stream_addr voltaire.local --kill_temp 38 --run_duration 120
...
E20220715 17:14:09.404217 1813575 main.cc:118] FATAL Device temperatue exceeded the kill threshold. HALTING! { kill_temp: 38, CPU_temp: 38, GPU_temp: 33.5 }.
```
